### PR TITLE
fix: minimal image dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,8 @@ COPY . .
 # Ensure the gradlew script is executable
 RUN chmod +x gradlew
 
+# Build the application
+RUN ./gradlew build --no-daemon
+
 # Start the application using the gradle wrapper and apprun task
-CMD ["./gradlew", "apprun"]
+ENTRYPOINT ["./gradlew", "apprun"]


### PR DESCRIPTION
# Summary
It is best practice to build everything first as part of the image building process and minimize unnecessary libs or files in the final image. 

Another good practice is to save the final executable (in this case, a .jar file) and remove dev libraries so that it is as minimal as possible. However, I'm not sure this is required for this assignment. 

The image after this change is bigger than however, the user would not have to perform the build process when trying to run a container using that image (1.19gb vs 770mb).

![image](https://github.com/user-attachments/assets/71dcc8c9-420b-41a3-919b-6d6ce78d10c7)